### PR TITLE
Added missing package to readme which makes nfs work on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We've tested this on OS X (Yosemite) and some flavor of linux that @ergonlogic u
 * [vagrant-triggers](https://github.com/emyl/vagrant-triggers)
 * [vagrant-dns](https://github.com/BerlinVagrant/vagrant-dns) *Mac only
 * [Drush 7.0-dev](https://github.com/drush-ops/drush)
-* NFS *Pre-installed on OS-X, install `nfs-common` package on linux.
+* NFS *Pre-installed on OS-X, install the `nfs-kernel-server` and `nfs-common` packages on Ubuntu Linux.
 
 The latest versions of all of the above are recommended. To install Drush on OS X, we recommend using [Homebrew](http://brew.sh/). You'll need to install the HEAD version of Drush: `brew install drush --HEAD`.
 


### PR DESCRIPTION
I tried to install Valkyrie based off of a suggestion in IRC only to find I didn't have all of the necessary NFS packages installed. I've added the other package that's required for Ubuntu in this PR. Down the line we may also want to add the names of packages for other common distros like Fedora or Arch Linux.
